### PR TITLE
Fix auto-matching when switching between files with different startAtRow

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -445,11 +445,50 @@ angular.element(document).ready(function () {
 
       // Try to auto-apply a matching configuration
       $scope.tryAutoApplyConfig = function () {
-        if (!$scope.data_object || !$scope.data_object.base_json) {
+        if (!$scope.data || !$scope.data.source || !$scope.data.source.data) {
+          return;
+        }
+
+        // Use findMatchingConfigWithStartRow to try multiple header rows
+        var match = ConfigMatcher.findMatchingConfigWithStartRow(
+          $scope.data.source.data,
+          $scope.filename,
+          $scope.file.chosenDelimiter === "auto"
+            ? null
+            : $scope.file.chosenDelimiter,
+        );
+
+        if (match && match.confidence >= 60) {
+          $scope.matchedConfig = match;
+
+          // Auto-apply if confidence is high enough
+          if (match.confidence >= 80) {
+            // Re-parse if startAtRow differs from current setting
+            var detectedRow =
+              match.detectedStartAtRow || match.config.startAtRow;
+            if (detectedRow && detectedRow !== $scope.file.startAtRow) {
+              $scope.file.startAtRow = detectedRow;
+              $scope.reparseFile();
+            }
+            $scope.applyConfig(match.config);
+            $scope.autoApplied = true;
+          }
+        }
+      };
+
+      // Try to auto-apply config for Excel files using already-parsed headers
+      // (Excel binary data can't be pre-parsed like CSV text)
+      $scope.tryAutoApplyConfigForExcel = function () {
+        if (!$scope.data_object || !$scope.data_object.fields) {
           return;
         }
 
         var headers = $scope.data_object.fields();
+        if (!headers || headers.length === 0) {
+          return;
+        }
+
+        // Try matching with current parsed headers
         var match = ConfigMatcher.findMatchingConfig(headers, $scope.filename);
 
         if (match && match.confidence >= 60) {
@@ -457,9 +496,55 @@ angular.element(document).ready(function () {
 
           // Auto-apply if confidence is high enough
           if (match.confidence >= 80) {
+            var configStartAtRow = match.config.startAtRow || 1;
+
+            // If the matched config has a different startAtRow, we need to re-parse
+            if (configStartAtRow !== $scope.file.startAtRow) {
+              $scope.file.startAtRow = configStartAtRow;
+              $scope.reparseFile();
+            }
+
             $scope.applyConfig(match.config);
             $scope.autoApplied = true;
+            return;
           }
+        }
+
+        // No high-confidence match with current startAtRow
+        // Try other saved startAtRow values
+        var allConfigs = ConfigMatcher.getAllConfigurations();
+        var triedRows = new Set([$scope.file.startAtRow]);
+
+        for (var configId in allConfigs) {
+          var config = allConfigs[configId];
+          var configRow = config.startAtRow || 1;
+
+          if (triedRows.has(configRow)) {
+            continue;
+          }
+          triedRows.add(configRow);
+
+          // Re-parse with this startAtRow
+          $scope.file.startAtRow = configRow;
+          $scope.reparseFile();
+
+          // Try matching again with new headers
+          headers = $scope.data_object.fields();
+          match = ConfigMatcher.findMatchingConfig(headers, $scope.filename);
+
+          if (match && match.confidence >= 80) {
+            $scope.matchedConfig = match;
+            $scope.applyConfig(match.config);
+            $scope.autoApplied = true;
+            return;
+          }
+        }
+
+        // No match found - reset to profile default if we changed it
+        var profileStartAtRow = $scope.profile.startAtRow || 1;
+        if ($scope.file.startAtRow !== profileStartAtRow) {
+          $scope.file.startAtRow = profileStartAtRow;
+          $scope.reparseFile();
         }
       };
 
@@ -650,9 +735,56 @@ angular.element(document).ready(function () {
             $scope.currentFilename = newValue.filename;
             $scope.filename = newValue.filename;
 
+            // Reset auto-match state first
+            $scope.matchedConfig = null;
+            $scope.autoApplied = false;
+
+            // Use profile defaults as baseline for matching, but preserve current
+            // file settings if no match is found
+            var profileStartAtRow = $scope.profile.startAtRow || 1;
+            var profileDelimiter = $scope.profile.chosenDelimiter || "auto";
+
+            // Try to find matching config BEFORE parsing (handles different startAtRow)
+            // Only for CSV files - Excel requires parsing first
+            if (!$scope.data_object.isExcelFile(newValue.filename)) {
+              var match = ConfigMatcher.findMatchingConfigWithStartRow(
+                newValue.data,
+                newValue.filename,
+                profileDelimiter === "auto" ? null : profileDelimiter,
+              );
+
+              if (match && match.confidence >= 80) {
+                $scope.matchedConfig = match;
+                // Use detected settings from matching config
+                $scope.file.startAtRow =
+                  match.detectedStartAtRow ||
+                  match.config.startAtRow ||
+                  profileStartAtRow;
+                $scope.file.chosenDelimiter =
+                  match.config.chosenDelimiter || profileDelimiter;
+                $scope.file.chosenEncoding =
+                  match.config.chosenEncoding || $scope.file.chosenEncoding;
+              } else {
+                // No match found - reset to profile defaults for fresh file
+                $scope.file.startAtRow = profileStartAtRow;
+                // Keep current delimiter if explicitly set, otherwise use profile
+                if (
+                  $scope.file.chosenDelimiter === "auto" ||
+                  !$scope.file.chosenDelimiter
+                ) {
+                  $scope.file.chosenDelimiter = profileDelimiter;
+                }
+              }
+            }
+
             // Process file based on type
             if ($scope.data_object.isExcelFile(newValue.filename)) {
-              // Parse as Excel file
+              // For Excel files, reset to profile defaults BEFORE parsing
+              // (we can't pre-detect headers from binary Excel data)
+              $scope.file.startAtRow = profileStartAtRow;
+              $scope.file.chosenDelimiter = profileDelimiter;
+
+              // Parse as Excel file with profile defaults
               $scope.data_object.parseExcel(
                 newValue.data,
                 newValue.filename,
@@ -673,8 +805,11 @@ angular.element(document).ready(function () {
                 $scope.file.selectedWorksheet = 0; // Default to first worksheet (index 0)
                 $scope.$evalAsync();
               }
+
+              // For Excel files, try auto-matching after parsing using parsed headers
+              $scope.tryAutoApplyConfigForExcel();
             } else {
-              // Parse as CSV file
+              // Parse as CSV file with detected settings
               if ($scope.file.chosenDelimiter == "auto") {
                 $scope.data_object.parseCsv(
                   newValue.data,
@@ -691,6 +826,15 @@ angular.element(document).ready(function () {
                   $scope.file.chosenDelimiter,
                 );
               }
+
+              // Apply matched config after parsing (for CSV)
+              if (
+                $scope.matchedConfig &&
+                $scope.matchedConfig.confidence >= 80
+              ) {
+                $scope.applyConfig($scope.matchedConfig.config);
+                $scope.autoApplied = true;
+              }
             }
 
             $scope.preview = $scope.data_object.converted_json(
@@ -699,11 +843,6 @@ angular.element(document).ready(function () {
               $scope.ynab_map,
               $scope.inverted_outflow,
             );
-
-            // Reset auto-match state and try to find matching config
-            $scope.matchedConfig = null;
-            $scope.autoApplied = false;
-            $scope.tryAutoApplyConfig();
           } catch (error) {
             console.error("Error parsing file:", error);
             alert("Error parsing file: " + error.message);

--- a/src/config_matcher.js
+++ b/src/config_matcher.js
@@ -147,50 +147,51 @@ var ConfigMatcher = (function () {
 
     startAtRow = startAtRow || 1;
 
-    // Split into lines, handling different line endings
-    var lines = content.split(/\r\n|\n|\r/);
+    // Use PapaParse with same transformHeader logic as data_object.js
+    // This ensures headers match what gets saved in configs
+    var existingHeaders = [];
+    var config = {
+      header: true,
+      skipEmptyLines: true,
+      preview: 1, // Only parse first row for headers
+      beforeFirstChunk: function (chunk) {
+        var rows = chunk.split("\n");
+        var startIndex = startAtRow - 1;
+        rows = rows.slice(startIndex);
+        return rows.join("\n");
+      },
+      transformHeader: function (header) {
+        if (header.trim().length === 0) {
+          header = "Unnamed column";
+        }
+        if (existingHeaders.indexOf(header) !== -1) {
+          var newHeader = header;
+          var counter = 0;
+          while (existingHeaders.indexOf(newHeader) !== -1) {
+            counter++;
+            newHeader = header + " (" + counter + ")";
+          }
+          header = newHeader;
+        }
+        existingHeaders.push(header);
+        return header;
+      },
+    };
 
-    // Get the header row (1-indexed, so subtract 1)
-    var headerRowIndex = startAtRow - 1;
-    if (headerRowIndex < 0 || headerRowIndex >= lines.length) {
-      return [];
+    if (delimiter && delimiter !== "auto") {
+      config.delimiter = delimiter;
     }
 
-    var headerLine = lines[headerRowIndex];
-
-    // Remove BOM if present
-    if (headerLine.charCodeAt(0) === 0xfeff) {
-      headerLine = headerLine.substring(1);
-    }
-
-    // Auto-detect delimiter if not provided
-    if (!delimiter || delimiter === "auto") {
-      // Count occurrences of common delimiters
-      var commaCount = (headerLine.match(/,/g) || []).length;
-      var semicolonCount = (headerLine.match(/;/g) || []).length;
-      var tabCount = (headerLine.match(/\t/g) || []).length;
-      var pipeCount = (headerLine.match(/\|/g) || []).length;
-
-      var maxCount = Math.max(commaCount, semicolonCount, tabCount, pipeCount);
-      if (maxCount === 0) {
-        delimiter = ","; // Default
-      } else if (semicolonCount === maxCount) {
-        delimiter = ";";
-      } else if (tabCount === maxCount) {
-        delimiter = "\t";
-      } else if (pipeCount === maxCount) {
-        delimiter = "|";
-      } else {
-        delimiter = ",";
+    try {
+      var result = Papa.parse(content, config);
+      if (result && result.meta && result.meta.fields) {
+        return result.meta.fields;
       }
+    } catch (e) {
+      console.error("Error parsing headers:", e);
     }
 
-    // Split by delimiter (basic - doesn't handle quoted fields with delimiters)
-    var headers = headerLine.split(delimiter).map(function (h) {
-      return h.trim().replace(/^["']|["']$/g, ""); // Remove surrounding quotes
-    });
-
-    return headers;
+    return [];
   }
 
   // ============================================

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1466,6 +1466,291 @@ describe("ParseController", () => {
       });
     });
 
+    describe("tryAutoApplyConfigForExcel", () => {
+      beforeEach(() => {
+        $scope.data_object.fields.mockReturnValue([
+          "Date",
+          "Description",
+          "Amount",
+        ]);
+        $scope.data_object.base_json = [{ Date: "2024-01-01" }];
+        $scope.filename = "test.xlsx";
+        $scope.reparseFile = jest.fn();
+      });
+
+      test("should return early if data_object is not available", () => {
+        $scope.data_object = null;
+
+        $scope.tryAutoApplyConfigForExcel();
+
+        expect(global.ConfigMatcher.findMatchingConfig).not.toHaveBeenCalled();
+      });
+
+      test("should return early if headers are empty", () => {
+        $scope.data_object.fields.mockReturnValue([]);
+
+        $scope.tryAutoApplyConfigForExcel();
+
+        expect(global.ConfigMatcher.findMatchingConfig).not.toHaveBeenCalled();
+      });
+
+      test("should auto-apply high confidence match with same startAtRow", () => {
+        const mockConfig = {
+          id: "excel-config",
+          columnFormat: ["Date", "Payee", "Memo", "Amount"],
+          chosenColumns: { Date: "Date" },
+          startAtRow: 1,
+        };
+
+        global.ConfigMatcher.findMatchingConfig.mockReturnValue({
+          configId: "excel-config",
+          matchType: "exact",
+          confidence: 100,
+          config: mockConfig,
+        });
+
+        $scope.file.startAtRow = 1;
+
+        $scope.tryAutoApplyConfigForExcel();
+
+        expect($scope.matchedConfig).toBeDefined();
+        expect($scope.autoApplied).toBe(true);
+        expect($scope.reparseFile).not.toHaveBeenCalled();
+      });
+
+      test("should re-parse when matched config has different startAtRow", () => {
+        const mockConfig = {
+          id: "excel-config",
+          columnFormat: ["Date", "Payee", "Memo", "Amount"],
+          chosenColumns: { Date: "Date" },
+          startAtRow: 3,
+        };
+
+        global.ConfigMatcher.findMatchingConfig.mockReturnValue({
+          configId: "excel-config",
+          matchType: "exact",
+          confidence: 100,
+          config: mockConfig,
+        });
+
+        $scope.file.startAtRow = 1;
+
+        $scope.tryAutoApplyConfigForExcel();
+
+        expect($scope.reparseFile).toHaveBeenCalled();
+        expect($scope.file.startAtRow).toBe(3);
+        expect($scope.autoApplied).toBe(true);
+      });
+
+      test("should store medium confidence match without auto-applying", () => {
+        const mockConfig = {
+          id: "excel-config",
+          columnFormat: ["Date", "Payee", "Memo", "Amount"],
+          chosenColumns: { Date: "Date" },
+        };
+
+        global.ConfigMatcher.findMatchingConfig.mockReturnValue({
+          configId: "excel-config",
+          matchType: "partial",
+          confidence: 70,
+          config: mockConfig,
+        });
+
+        $scope.tryAutoApplyConfigForExcel();
+
+        expect($scope.matchedConfig).toBeDefined();
+        expect($scope.autoApplied).toBe(false);
+      });
+
+      test("should try different startAtRow values from saved configs", () => {
+        // First match returns low confidence
+        global.ConfigMatcher.findMatchingConfig
+          .mockReturnValueOnce(null)
+          .mockReturnValueOnce({
+            configId: "found-config",
+            matchType: "exact",
+            confidence: 100,
+            config: {
+              columnFormat: ["Date", "Payee", "Memo", "Amount"],
+              startAtRow: 3,
+            },
+          });
+
+        // Saved configs with different startAtRow values
+        global.ConfigMatcher.getAllConfigurations.mockReturnValue({
+          "config-1": { startAtRow: 1 },
+          "config-2": { startAtRow: 3 },
+        });
+
+        $scope.file.startAtRow = 1;
+
+        $scope.tryAutoApplyConfigForExcel();
+
+        expect($scope.reparseFile).toHaveBeenCalled();
+        expect($scope.autoApplied).toBe(true);
+      });
+
+      test("should reset to profile default when no match found after trying all rows", () => {
+        global.ConfigMatcher.findMatchingConfig.mockReturnValue(null);
+        global.ConfigMatcher.getAllConfigurations.mockReturnValue({
+          "config-1": { startAtRow: 2 },
+        });
+
+        $scope.file.startAtRow = 1;
+        $scope.profile.startAtRow = 1;
+
+        $scope.tryAutoApplyConfigForExcel();
+
+        // Should have tried row 2, then reset back to profile default (1)
+        expect($scope.file.startAtRow).toBe(1);
+      });
+
+      test("should skip already tried startAtRow values", () => {
+        global.ConfigMatcher.findMatchingConfig.mockReturnValue(null);
+        global.ConfigMatcher.getAllConfigurations.mockReturnValue({
+          "config-1": { startAtRow: 1 }, // Same as current
+          "config-2": { startAtRow: 1 }, // Duplicate
+        });
+
+        $scope.file.startAtRow = 1;
+        $scope.profile.startAtRow = 1;
+
+        $scope.tryAutoApplyConfigForExcel();
+
+        // Should not call reparseFile since all configs have same startAtRow
+        expect($scope.reparseFile).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("saveConfigWithName", () => {
+      beforeEach(() => {
+        global.prompt = jest.fn();
+        $scope.saveCurrentConfig = jest.fn();
+      });
+
+      afterEach(() => {
+        delete global.prompt;
+      });
+
+      test("should prompt for name and save config", () => {
+        global.prompt.mockReturnValue("My Custom Config");
+
+        $scope.saveConfigWithName();
+
+        expect(global.prompt).toHaveBeenCalled();
+        expect($scope.saveCurrentConfig).toHaveBeenCalledWith(
+          "My Custom Config",
+        );
+      });
+
+      test("should not save if user cancels prompt", () => {
+        global.prompt.mockReturnValue(null);
+
+        $scope.saveConfigWithName();
+
+        expect($scope.saveCurrentConfig).not.toHaveBeenCalled();
+      });
+
+      test("should prevent default event if provided", () => {
+        const mockEvent = { preventDefault: jest.fn() };
+        global.prompt.mockReturnValue("Test");
+
+        $scope.saveConfigWithName(mockEvent);
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+      });
+
+      test("should use matched config name as default when available", () => {
+        $scope.matchedConfig = {
+          config: { name: "Existing Config Name" },
+        };
+        global.prompt.mockReturnValue("New Name");
+
+        $scope.saveConfigWithName();
+
+        expect(global.prompt).toHaveBeenCalledWith(
+          "Enter a name for this configuration:",
+          "Existing Config Name",
+        );
+      });
+
+      test("should use filename as default when no matched config", () => {
+        $scope.matchedConfig = null;
+        $scope.filename = "my_bank_statement.csv";
+        global.prompt.mockReturnValue("New Name");
+
+        $scope.saveConfigWithName();
+
+        expect(global.prompt).toHaveBeenCalledWith(
+          "Enter a name for this configuration:",
+          "my_bank_statement.csv",
+        );
+      });
+    });
+
+    describe("promptRenameConfig", () => {
+      beforeEach(() => {
+        global.prompt = jest.fn();
+        $scope.renameConfig = jest.fn();
+      });
+
+      afterEach(() => {
+        delete global.prompt;
+      });
+
+      test("should prompt for new name and rename config", () => {
+        global.ConfigMatcher.getConfiguration.mockReturnValue({
+          name: "Old Name",
+        });
+        global.prompt.mockReturnValue("New Name");
+
+        $scope.promptRenameConfig("config-id");
+
+        expect(global.ConfigMatcher.getConfiguration).toHaveBeenCalledWith(
+          "config-id",
+        );
+        expect(global.prompt).toHaveBeenCalledWith(
+          "Enter a new name:",
+          "Old Name",
+        );
+        expect($scope.renameConfig).toHaveBeenCalledWith(
+          "config-id",
+          "New Name",
+        );
+      });
+
+      test("should not rename if config not found", () => {
+        global.ConfigMatcher.getConfiguration.mockReturnValue(null);
+
+        $scope.promptRenameConfig("nonexistent-id");
+
+        expect(global.prompt).not.toHaveBeenCalled();
+        expect($scope.renameConfig).not.toHaveBeenCalled();
+      });
+
+      test("should not rename if user cancels prompt", () => {
+        global.ConfigMatcher.getConfiguration.mockReturnValue({
+          name: "Old Name",
+        });
+        global.prompt.mockReturnValue(null);
+
+        $scope.promptRenameConfig("config-id");
+
+        expect($scope.renameConfig).not.toHaveBeenCalled();
+      });
+
+      test("should not rename if new name is same as old name", () => {
+        global.ConfigMatcher.getConfiguration.mockReturnValue({
+          name: "Same Name",
+        });
+        global.prompt.mockReturnValue("Same Name");
+
+        $scope.promptRenameConfig("config-id");
+
+        expect($scope.renameConfig).not.toHaveBeenCalled();
+      });
+    });
+
     describe("downloadFile auto-save", () => {
       beforeEach(() => {
         const mockAnchor = {

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -42,6 +42,7 @@ global.ConfigMatcher = {
   getAllConfigurations: jest.fn(() => ({})),
   getConfiguration: jest.fn(),
   findMatchingConfig: jest.fn(),
+  findMatchingConfigWithStartRow: jest.fn(),
   saveConfiguration: jest.fn(),
   updateConfiguration: jest.fn(),
   deleteConfiguration: jest.fn(),
@@ -606,9 +607,9 @@ describe("ParseController", () => {
       const controllerFn = parseControllerCall[1];
       controllerFn($scope, $location);
 
-      // Set up Excel file scenario with custom delimiter
+      // Set up Excel file scenario with custom delimiter in profile
       $scope.data_object.isExcelFile.mockReturnValue(true);
-      $scope.file.chosenDelimiter = ";";
+      $scope.profile.chosenDelimiter = ";";
 
       const excelData = {
         data: "excel_binary_data",
@@ -1105,6 +1106,7 @@ describe("ParseController", () => {
       global.ConfigMatcher.getAllConfigurations.mockReturnValue({});
       global.ConfigMatcher.getConfiguration.mockReturnValue(null);
       global.ConfigMatcher.findMatchingConfig.mockReturnValue(null);
+      global.ConfigMatcher.findMatchingConfigWithStartRow.mockReturnValue(null);
       global.ConfigMatcher.saveConfiguration.mockReturnValue(null);
       global.ConfigMatcher.updateConfiguration.mockReturnValue(false);
       global.ConfigMatcher.deleteConfiguration.mockReturnValue(false);
@@ -1124,15 +1126,25 @@ describe("ParseController", () => {
         { Date: "2024-01-01", Payee: "Store", Amount: "-50.00" },
       ]);
       $scope.filename = "test.csv";
+
+      // Set up data.source for tryAutoApplyConfig (it now reads raw content)
+      $scope.data = {
+        source: {
+          data: "Date,Description,Amount\n2024-01-01,Store,-50.00",
+          filename: "test.csv",
+        },
+      };
     });
 
     describe("tryAutoApplyConfig", () => {
-      test("should not attempt matching if data_object has no data", () => {
-        $scope.data_object.base_json = null;
+      test("should not attempt matching if data.source is not available", () => {
+        $scope.data = null;
 
         $scope.tryAutoApplyConfig();
 
-        expect(global.ConfigMatcher.findMatchingConfig).not.toHaveBeenCalled();
+        expect(
+          global.ConfigMatcher.findMatchingConfigWithStartRow,
+        ).not.toHaveBeenCalled();
         expect($scope.matchedConfig).toBeNull();
       });
 
@@ -1148,7 +1160,7 @@ describe("ParseController", () => {
           },
         };
 
-        global.ConfigMatcher.findMatchingConfig.mockReturnValue({
+        global.ConfigMatcher.findMatchingConfigWithStartRow.mockReturnValue({
           configId: "test-config-id",
           matchType: "exact",
           confidence: 100,
@@ -1157,9 +1169,12 @@ describe("ParseController", () => {
 
         $scope.tryAutoApplyConfig();
 
-        expect(global.ConfigMatcher.findMatchingConfig).toHaveBeenCalledWith(
-          ["Date", "Description", "Amount"],
+        expect(
+          global.ConfigMatcher.findMatchingConfigWithStartRow,
+        ).toHaveBeenCalledWith(
+          "Date,Description,Amount\n2024-01-01,Store,-50.00",
           "test.csv",
+          null,
         );
         expect($scope.matchedConfig).toBeDefined();
         expect($scope.matchedConfig.confidence).toBe(100);
@@ -1175,7 +1190,7 @@ describe("ParseController", () => {
           startAtRow: 2,
         };
 
-        global.ConfigMatcher.findMatchingConfig.mockReturnValue({
+        global.ConfigMatcher.findMatchingConfigWithStartRow.mockReturnValue({
           configId: "test-config-id",
           matchType: "exact",
           confidence: 85,
@@ -1197,7 +1212,7 @@ describe("ParseController", () => {
           chosenColumns: { Date: "Date" },
         };
 
-        global.ConfigMatcher.findMatchingConfig.mockReturnValue({
+        global.ConfigMatcher.findMatchingConfigWithStartRow.mockReturnValue({
           configId: "test-config-id",
           matchType: "partial",
           confidence: 70,
@@ -1212,7 +1227,7 @@ describe("ParseController", () => {
       });
 
       test("should not store config when confidence < 60", () => {
-        global.ConfigMatcher.findMatchingConfig.mockReturnValue({
+        global.ConfigMatcher.findMatchingConfigWithStartRow.mockReturnValue({
           configId: "test-config-id",
           matchType: "filename",
           confidence: 50,
@@ -1502,8 +1517,8 @@ describe("ParseController", () => {
       });
     });
 
-    describe("tryAutoApplyConfig in data.source watcher", () => {
-      test("should call tryAutoApplyConfig after parsing file", () => {
+    describe("auto-matching in data.source watcher", () => {
+      test("should apply matching config for CSV files before parsing", () => {
         // Set up watchers
         const watchCallbacks = {};
         $scope.$watch.mockImplementation((expr, callback) => {
@@ -1524,29 +1539,34 @@ describe("ParseController", () => {
         $scope.data_object.isExcelFile.mockReturnValue(false);
         $scope.data_object.base_json = [{ Date: "2024-01-01" }];
 
-        // Set up matching config
+        // Set up matching config with different startAtRow
         const mockConfig = {
           id: "auto-match-id",
           columnFormat: ["Date", "Payee", "Memo", "Amount"],
           chosenColumns: { Date: "Date" },
+          startAtRow: 3,
         };
-        global.ConfigMatcher.findMatchingConfig.mockReturnValue({
+        global.ConfigMatcher.findMatchingConfigWithStartRow.mockReturnValue({
           configId: "auto-match-id",
           matchType: "exact",
           confidence: 100,
           config: mockConfig,
+          detectedStartAtRow: 3,
         });
 
         const csvData = {
-          data: "Date,Payee,Amount\n2024-01-01,Store,-50.00",
+          data: "Header1\nHeader2\nDate,Payee,Amount\n2024-01-01,Store,-50.00",
           filename: "test.csv",
         };
 
         watchCallbacks["data.source"](csvData, null);
 
-        expect(global.ConfigMatcher.findMatchingConfig).toHaveBeenCalled();
+        expect(
+          global.ConfigMatcher.findMatchingConfigWithStartRow,
+        ).toHaveBeenCalled();
         expect($scope.matchedConfig).toBeDefined();
         expect($scope.autoApplied).toBe(true);
+        expect($scope.file.startAtRow).toBe(3);
       });
 
       test("should reset auto-match state before trying to match", () => {
@@ -1572,7 +1592,9 @@ describe("ParseController", () => {
         $scope.data_object.isExcelFile.mockReturnValue(false);
 
         // No matching config this time
-        global.ConfigMatcher.findMatchingConfig.mockReturnValue(null);
+        global.ConfigMatcher.findMatchingConfigWithStartRow.mockReturnValue(
+          null,
+        );
 
         const csvData = {
           data: "NewHeader1,NewHeader2\nval1,val2",

--- a/tests/config_matcher.test.js
+++ b/tests/config_matcher.test.js
@@ -33,6 +33,93 @@ describe("ConfigMatcher", () => {
       configurable: true,
     });
 
+    // Mock PapaParse for extractHeadersFromContent
+    global.Papa = {
+      parse: jest.fn((content, config) => {
+        // Simple CSV parsing for tests
+        let lines = content.split(/\r\n|\n|\r/);
+
+        // Apply beforeFirstChunk if provided
+        if (config.beforeFirstChunk) {
+          const transformed = config.beforeFirstChunk(content);
+          lines = transformed.split(/\r\n|\n|\r/);
+        }
+
+        // Check if content is empty after processing
+        if (lines.length === 0 || (lines.length === 1 && lines[0] === "")) {
+          return { meta: { fields: [] }, data: [] };
+        }
+
+        // Get header line
+        let headerLine = lines[0] || "";
+
+        // Return empty if line is empty
+        if (!headerLine || headerLine.trim() === "") {
+          return { meta: { fields: [] }, data: [] };
+        }
+
+        // Remove BOM if present
+        if (headerLine.charCodeAt(0) === 0xfeff) {
+          headerLine = headerLine.substring(1);
+        }
+
+        // Auto-detect delimiter if not specified
+        let delimiter = config.delimiter;
+        if (!delimiter) {
+          // Count occurrences of common delimiters
+          const commaCount = (headerLine.match(/,/g) || []).length;
+          const semicolonCount = (headerLine.match(/;/g) || []).length;
+          const tabCount = (headerLine.match(/\t/g) || []).length;
+          const pipeCount = (headerLine.match(/\|/g) || []).length;
+
+          const maxCount = Math.max(
+            commaCount,
+            semicolonCount,
+            tabCount,
+            pipeCount,
+          );
+          if (maxCount === 0) {
+            delimiter = ",";
+          } else if (semicolonCount === maxCount) {
+            delimiter = ";";
+          } else if (tabCount === maxCount) {
+            delimiter = "\t";
+          } else if (pipeCount === maxCount) {
+            delimiter = "|";
+          } else {
+            delimiter = ",";
+          }
+        }
+
+        // Split headers, handling quotes
+        let headers = [];
+        let current = "";
+        let inQuotes = false;
+        for (let i = 0; i < headerLine.length; i++) {
+          const char = headerLine[i];
+          if (char === '"' && (i === 0 || headerLine[i - 1] !== "\\")) {
+            inQuotes = !inQuotes;
+          } else if (char === delimiter && !inQuotes) {
+            headers.push(current.trim().replace(/^["']|["']$/g, ""));
+            current = "";
+          } else {
+            current += char;
+          }
+        }
+        headers.push(current.trim().replace(/^["']|["']$/g, ""));
+
+        // Apply transformHeader if provided
+        if (config.transformHeader) {
+          headers = headers.map(config.transformHeader);
+        }
+
+        return {
+          meta: { fields: headers },
+          data: [],
+        };
+      }),
+    };
+
     // Clear module cache and re-require
     delete require.cache[require.resolve("../src/config_matcher.js")];
     ConfigMatcher = require("../src/config_matcher.js");

--- a/tests/config_matcher.test.js
+++ b/tests/config_matcher.test.js
@@ -208,6 +208,38 @@ describe("ConfigMatcher", () => {
 
       expect(fp1).not.toBe(fp2);
     });
+
+    test("should return null when all headers are empty after filtering", () => {
+      const headers = ["", "   ", "\t"];
+      const fp = ConfigMatcher.generateFingerprint(headers);
+
+      expect(fp).toBeNull();
+    });
+  });
+
+  describe("jaccardSimilarity internal function", () => {
+    test("should return 100 for two empty sets when matching empty headers against empty originalHeaders", () => {
+      // Set up a config with empty originalHeaders and chosenColumns
+      const storedData = {
+        configs: {
+          fp_123: {
+            id: "fp_123",
+            name: "Empty Config",
+            chosenColumns: {},
+            originalHeaders: [],
+          },
+        },
+      };
+      mockStore.knownConfigurations = JSON.stringify(storedData);
+
+      // Match with empty headers - both sets become empty, which returns 100 similarity
+      const match = ConfigMatcher.findMatchingConfig([], "test.csv");
+
+      // Should get a partial match with 100% confidence (two empty sets are considered identical)
+      expect(match).not.toBeNull();
+      expect(match.matchType).toBe("partial");
+      expect(match.confidence).toBe(100);
+    });
   });
 
   // ============================================
@@ -379,6 +411,36 @@ describe("ConfigMatcher", () => {
       const headers = ConfigMatcher.extractHeadersFromContent(content);
 
       expect(headers).toEqual(["Date", "Description", "Amount"]);
+    });
+
+    test("should handle duplicate headers by adding suffix", () => {
+      const content = "Date,Amount,Date,Amount\n2024-01-01,-50,2024-01-02,-100";
+      const headers = ConfigMatcher.extractHeadersFromContent(content);
+
+      // Should have renamed duplicates
+      expect(headers).toContain("Date");
+      expect(headers).toContain("Amount");
+      expect(headers).toContain("Date (1)");
+      expect(headers).toContain("Amount (1)");
+    });
+
+    test("should handle empty headers by naming them 'Unnamed column'", () => {
+      const content = "Date,,Amount\n2024-01-01,value,-50";
+      const headers = ConfigMatcher.extractHeadersFromContent(content);
+
+      expect(headers).toContain("Date");
+      expect(headers).toContain("Unnamed column");
+      expect(headers).toContain("Amount");
+    });
+
+    test("should handle multiple empty headers with suffix", () => {
+      const content = "Date,,,Amount\n2024-01-01,a,b,-50";
+      const headers = ConfigMatcher.extractHeadersFromContent(content);
+
+      expect(headers).toContain("Date");
+      expect(headers).toContain("Unnamed column");
+      expect(headers).toContain("Unnamed column (1)");
+      expect(headers).toContain("Amount");
     });
 
     test("should extract headers from real test files", () => {
@@ -621,6 +683,117 @@ describe("ConfigMatcher", () => {
       expect(result).toBe(true);
       const savedData = JSON.parse(mockStore.knownConfigurations);
       expect(savedData.configs.fp_123.name).toBe("New Name");
+    });
+  });
+
+  describe("incrementUsageCount", () => {
+    test("should increment usage count for existing config", () => {
+      const storedData = {
+        configs: {
+          fp_123: { id: "fp_123", name: "Test", useCount: 5 },
+        },
+      };
+      mockStore.knownConfigurations = JSON.stringify(storedData);
+
+      const result = ConfigMatcher.incrementUsageCount("fp_123");
+
+      expect(result).toBe(true);
+      const savedData = JSON.parse(mockStore.knownConfigurations);
+      expect(savedData.configs.fp_123.useCount).toBe(6);
+      expect(savedData.configs.fp_123.lastUsed).toBeDefined();
+    });
+
+    test("should return false for non-existent config", () => {
+      const result = ConfigMatcher.incrementUsageCount("fp_nonexistent");
+
+      expect(result).toBe(false);
+    });
+
+    test("should initialize useCount if not present", () => {
+      const storedData = {
+        configs: {
+          fp_123: { id: "fp_123", name: "Test" },
+        },
+      };
+      mockStore.knownConfigurations = JSON.stringify(storedData);
+
+      ConfigMatcher.incrementUsageCount("fp_123");
+
+      const savedData = JSON.parse(mockStore.knownConfigurations);
+      expect(savedData.configs.fp_123.useCount).toBe(1);
+    });
+  });
+
+  // ============================================
+  // Error Handling Tests
+  // ============================================
+
+  describe("error handling", () => {
+    test("should handle invalid JSON in localStorage gracefully", () => {
+      mockStore.knownConfigurations = "invalid json {{{";
+      global.console.warn = jest.fn();
+
+      const configs = ConfigMatcher.getAllConfigurations();
+
+      expect(configs).toEqual({});
+      expect(global.console.warn).toHaveBeenCalledWith(
+        "ConfigMatcher: Failed to parse stored configs",
+        expect.any(Error),
+      );
+
+      delete global.console.warn;
+    });
+
+    test("should handle localStorage without configs property", () => {
+      mockStore.knownConfigurations = JSON.stringify({ notConfigs: {} });
+
+      const configs = ConfigMatcher.getAllConfigurations();
+
+      expect(configs).toEqual({});
+    });
+
+    test("should handle localStorage setItem failure", () => {
+      global.console.warn = jest.fn();
+
+      // Make setItem throw an error (simulating quota exceeded)
+      global.localStorage.setItem.mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+
+      const headers = ["Date", "Amount"];
+      const result = ConfigMatcher.saveConfiguration(headers, "test.csv", {
+        columnFormat: [],
+        chosenColumns: {},
+      });
+
+      expect(result).toBeNull();
+      expect(global.console.warn).toHaveBeenCalledWith(
+        "ConfigMatcher: Failed to save configs",
+        expect.any(Error),
+      );
+
+      delete global.console.warn;
+    });
+
+    test("should handle PapaParse errors gracefully", () => {
+      global.console.error = jest.fn();
+
+      // Make Papa.parse throw an error
+      global.Papa.parse.mockImplementation(() => {
+        throw new Error("Parse error");
+      });
+
+      const headers = ConfigMatcher.extractHeadersFromContent(
+        "Date,Amount\n2024-01-01,-50",
+      );
+
+      expect(headers).toEqual([]);
+      expect(global.console.error).toHaveBeenCalledWith(
+        "Error parsing headers:",
+        expect.any(Error),
+      );
+
+      delete global.console.error;
     });
   });
 


### PR DESCRIPTION
The issue was that when switching between files (e.g., CSV with row 1 headers and XLS with row 3 headers), the auto-matching would fail because:

1. The startAtRow setting persisted from the previous file's config
2. findMatchingConfigWithStartRow was not being called in the data.source watcher
3. extractHeadersFromContent returned different headers than PapaParse

Changes:
- Restructure data.source watcher to try matching BEFORE parsing for CSV files
- Update extractHeadersFromContent to use PapaParse with same transformHeader logic as data_object.js for consistent header format
- Reset file settings to profile defaults before matching/parsing new file
- Update tryAutoApplyConfig to use findMatchingConfigWithStartRow
- Add PapaParse mock to config_matcher tests

This ensures that when files with different startAtRow values are uploaded, the correct startAtRow is detected and applied before parsing.