### PR TITLE
Add fix dates toggle for 2-digit year conversion

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,6 +304,14 @@
                 </div>
                 <div
                   class="btn btn-outline-secondary"
+                  ng-class="{'active': fix_dates}"
+                  ng-click="toggle_fix_dates()"
+                  data-testid="fix-dates-button"
+                >
+                  <i class="fa fa-calendar"></i> Fix dates
+                </div>
+                <div
+                  class="btn btn-outline-secondary"
                   ng-click="toggleColumnFormat()"
                   data-testid="toggle-format-button"
                 >

--- a/src/app.js
+++ b/src/app.js
@@ -323,6 +323,7 @@ angular.element(document).ready(function () {
         $scope.ynab_map = $scope.profile.chosenColumns;
         $scope.inverted_outflow = false;
         $scope.inverted_amount = false;
+        $scope.fix_dates = false;
         $scope.file = {
           encodings: encodings,
           delimiters: delimiters,
@@ -415,6 +416,7 @@ angular.element(document).ready(function () {
               $scope.ynab_map,
               $scope.inverted_outflow,
               $scope.inverted_amount,
+              $scope.fix_dates,
             );
 
             // Save settings to profile
@@ -583,6 +585,9 @@ angular.element(document).ready(function () {
         if (typeof config.invertedAmount !== "undefined") {
           $scope.inverted_amount = config.invertedAmount;
         }
+        if (typeof config.fixDates !== "undefined") {
+          $scope.fix_dates = config.fixDates;
+        }
 
         // Update preview
         $scope.preview = $scope.data_object.converted_json(
@@ -591,6 +596,7 @@ angular.element(document).ready(function () {
           $scope.ynab_map,
           $scope.inverted_outflow,
           $scope.inverted_amount,
+          $scope.fix_dates,
         );
 
         // Increment usage count
@@ -615,6 +621,7 @@ angular.element(document).ready(function () {
           extraRow: $scope.file.extraRow,
           invertedOutflow: $scope.inverted_outflow,
           invertedAmount: $scope.inverted_amount,
+          fixDates: $scope.fix_dates,
         };
 
         var configId = ConfigMatcher.saveConfiguration(
@@ -654,6 +661,7 @@ angular.element(document).ready(function () {
             extraRow: $scope.file.extraRow,
             invertedOutflow: $scope.inverted_outflow,
             invertedAmount: $scope.inverted_amount,
+            fixDates: $scope.fix_dates,
           },
         );
 
@@ -845,12 +853,20 @@ angular.element(document).ready(function () {
               }
             }
 
+            // Auto-detect short year dates after file load
+            if ($scope.ynab_map && $scope.ynab_map.Date) {
+              if ($scope.data_object.hasShortYearDates($scope.ynab_map.Date)) {
+                $scope.fix_dates = true;
+              }
+            }
+
             $scope.preview = $scope.data_object.converted_json(
               10,
               $scope.ynab_cols,
               $scope.ynab_map,
               $scope.inverted_outflow,
               $scope.inverted_amount,
+              $scope.fix_dates,
             );
           } catch (error) {
             console.error("Error parsing file:", error);
@@ -866,6 +882,7 @@ angular.element(document).ready(function () {
             $scope.ynab_map,
             $scope.inverted_outflow,
             $scope.inverted_amount,
+            $scope.fix_dates,
           );
         }
       });
@@ -877,6 +894,19 @@ angular.element(document).ready(function () {
             $scope.ynab_map,
             $scope.inverted_outflow,
             $scope.inverted_amount,
+            $scope.fix_dates,
+          );
+        }
+      });
+      $scope.$watch("fix_dates", function (newValue, oldValue) {
+        if (newValue != oldValue) {
+          $scope.preview = $scope.data_object.converted_json(
+            10,
+            $scope.ynab_cols,
+            $scope.ynab_map,
+            $scope.inverted_outflow,
+            $scope.inverted_amount,
+            $scope.fix_dates,
           );
         }
       });
@@ -885,12 +915,26 @@ angular.element(document).ready(function () {
         function (newValue, oldValue) {
           $scope.profile.chosenColumns = newValue;
           localStorage.setItem("profiles", JSON.stringify($scope.profiles));
+          // Auto-detect short year dates when Date mapping changes
+          if (
+            newValue &&
+            newValue.Date &&
+            (!oldValue || newValue.Date !== oldValue.Date)
+          ) {
+            if (
+              $scope.data_object.hasShortYearDates &&
+              $scope.data_object.hasShortYearDates(newValue.Date)
+            ) {
+              $scope.fix_dates = true;
+            }
+          }
           $scope.preview = $scope.data_object.converted_json(
             10,
             $scope.ynab_cols,
             newValue,
             $scope.inverted_outflow,
             $scope.inverted_amount,
+            $scope.fix_dates,
           );
         },
         true,
@@ -902,6 +946,7 @@ angular.element(document).ready(function () {
           $scope.ynab_map,
           $scope.inverted_outflow,
           $scope.inverted_amount,
+          $scope.fix_dates,
         );
       };
       $scope.reloadApp = function () {
@@ -912,6 +957,9 @@ angular.element(document).ready(function () {
       };
       $scope.invert_amount = function () {
         $scope.inverted_amount = !$scope.inverted_amount;
+      };
+      $scope.toggle_fix_dates = function () {
+        $scope.fix_dates = !$scope.fix_dates;
       };
 
       // Handle worksheet selection for Excel files
@@ -947,6 +995,7 @@ angular.element(document).ready(function () {
               $scope.ynab_map,
               $scope.inverted_outflow,
               $scope.inverted_amount,
+              $scope.fix_dates,
             );
             $scope.$evalAsync();
           } catch (error) {

--- a/src/config_matcher.js
+++ b/src/config_matcher.js
@@ -487,6 +487,7 @@ var ConfigMatcher = (function () {
       extraRow: settings.extraRow || false,
       invertedOutflow: settings.invertedOutflow || false,
       invertedAmount: settings.invertedAmount || false,
+      fixDates: settings.fixDates || false,
       createdAt: existingConfig ? existingConfig.createdAt : now,
       lastUsed: now,
       useCount: (existingConfig ? existingConfig.useCount : 0) + 1,

--- a/src/data_object.js
+++ b/src/data_object.js
@@ -169,6 +169,41 @@ window.DataObject = class DataObject {
     return this.base_json.data;
   }
 
+  static fixTwoDigitYear(dateStr) {
+    if (!dateStr) return dateStr;
+    if (/\d{4}/.test(dateStr)) return dateStr;
+    // Year at start: YY-MM-DD, YY/MM/DD — only when first part > 31 (unambiguously a year)
+    var startMatch = dateStr.match(/^(\d{2})([/\-.]\d{1,2}[/\-.]\d{1,2})$/);
+    if (startMatch && parseInt(startMatch[1], 10) > 31) {
+      return "20" + startMatch[1] + startMatch[2];
+    }
+    // Year at end: MM/DD/YY, DD.MM.YY, DD-MM-YY
+    dateStr = dateStr.replace(
+      /^(\d{1,2}[/\-.]\d{1,2}[/\-.])(\d{2})$/,
+      "$120$2",
+    );
+    return dateStr;
+  }
+
+  hasShortYearDates(dateColumnName) {
+    if (!this.base_json || !this.base_json.data || !dateColumnName) {
+      return false;
+    }
+    var rows = this.base_json.data.slice(0, 10);
+    var shortCount = 0;
+    var total = 0;
+    rows.forEach(function (row) {
+      var val = row[dateColumnName];
+      if (val && typeof val === "string" && val.trim().length > 0) {
+        total++;
+        if (!/\d{4}/.test(val)) {
+          shortCount++;
+        }
+      }
+    });
+    return total > 0 && shortCount > total / 2;
+  }
+
   // This method converts base_json into a json file with YNAB specific fields based on
   //   which fields you choose in the dropdowns in the browser.
 
@@ -179,12 +214,14 @@ window.DataObject = class DataObject {
   //     convert the uploaded CSV file into the columns that YNAB expects.
   // inverted_outflow: if true, positive values represent outflow while negative values represent inflow
   // inverted_amount: if true, flip the sign on Amount values (positive becomes negative, negative becomes positive)
+  // fix_dates: if true, convert 2-digit years to 4-digit years in Date column
   converted_json(
     limit,
     ynab_cols,
     lookup,
     inverted_outflow = false,
     inverted_amount = false,
+    fix_dates = false,
   ) {
     var value;
     if (this.base_json === null) {
@@ -204,6 +241,11 @@ window.DataObject = class DataObject {
             //   the rest are just returned as they are.
             if (cell) {
               switch (col) {
+                case "Date":
+                  tmp_row[col] = fix_dates
+                    ? DataObject.fixTwoDigitYear(cell)
+                    : cell;
+                  break;
                 case "Outflow":
                   if (lookup["Outflow"] == lookup["Inflow"]) {
                     if (!inverted_outflow) {
@@ -248,7 +290,14 @@ window.DataObject = class DataObject {
     return value;
   }
 
-  converted_csv(limit, ynab_cols, lookup, inverted_outflow, inverted_amount) {
+  converted_csv(
+    limit,
+    ynab_cols,
+    lookup,
+    inverted_outflow,
+    inverted_amount,
+    fix_dates = false,
+  ) {
     var string;
     if (this.base_json === null) {
       return nil;
@@ -261,6 +310,7 @@ window.DataObject = class DataObject {
       lookup,
       inverted_outflow,
       inverted_amount,
+      fix_dates,
     ).forEach(function (row) {
       var row_values;
       row_values = [];

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -23,6 +23,7 @@ global.DataObject = jest.fn(() => ({
   converted_csv: jest.fn(),
   fields: jest.fn(() => []),
   rows: jest.fn(() => []),
+  hasShortYearDates: jest.fn(() => false),
   worksheetNames: [],
   currentWorksheet: null,
 }));
@@ -200,6 +201,20 @@ describe("ParseController", () => {
       expect($scope.inverted_amount).toBe(false);
     });
 
+    test("should initialize fix_dates to false", () => {
+      expect($scope.fix_dates).toBe(false);
+    });
+
+    test("should toggle fix_dates when toggle is called", () => {
+      expect($scope.fix_dates).toBe(false);
+
+      $scope.toggle_fix_dates();
+      expect($scope.fix_dates).toBe(true);
+
+      $scope.toggle_fix_dates();
+      expect($scope.fix_dates).toBe(false);
+    });
+
     test("should reset app state when reloadApp is called", () => {
       $scope.setInitialScopeState = jest.fn();
       $scope.reloadApp();
@@ -260,6 +275,7 @@ describe("ParseController", () => {
         $scope.ynab_map,
         $scope.inverted_outflow,
         $scope.inverted_amount,
+        $scope.fix_dates,
       );
     });
 
@@ -330,6 +346,7 @@ describe("ParseController", () => {
         $scope.ynab_map,
         $scope.inverted_outflow,
         $scope.inverted_amount,
+        $scope.fix_dates,
       );
     });
 
@@ -363,6 +380,38 @@ describe("ParseController", () => {
         $scope.ynab_map,
         $scope.inverted_outflow,
         $scope.inverted_amount,
+        $scope.fix_dates,
+      );
+    });
+
+    test("should update preview when fix_dates changes", () => {
+      // Set up watchers
+      const watchCallbacks = {};
+      $scope.$watch.mockImplementation((expr, callback) => {
+        watchCallbacks[expr] = callback;
+      });
+
+      // Re-initialize to capture watch callbacks
+      jest.resetModules();
+      require("../src/app.js");
+      const controllerCalls = mockModule.controller.mock.calls;
+      const parseControllerCall = controllerCalls.find(
+        (call) => call[0] === "ParseController",
+      );
+      const controllerFn = parseControllerCall[1];
+      controllerFn($scope, $location);
+
+      // Simulate fix_dates change
+      $scope.fix_dates = true;
+      watchCallbacks["fix_dates"](true, false);
+
+      expect($scope.data_object.converted_json).toHaveBeenCalledWith(
+        10,
+        $scope.ynab_cols,
+        $scope.ynab_map,
+        $scope.inverted_outflow,
+        $scope.inverted_amount,
+        $scope.fix_dates,
       );
     });
 
@@ -394,6 +443,7 @@ describe("ParseController", () => {
         newMapping,
         $scope.inverted_outflow,
         $scope.inverted_amount,
+        $scope.fix_dates,
       );
     });
 
@@ -410,6 +460,7 @@ describe("ParseController", () => {
         $scope.ynab_map,
         $scope.inverted_outflow,
         $scope.inverted_amount,
+        $scope.fix_dates,
       );
       expect(result).toBe("Date,Payee,Amount\n2024-01-01,Store,-50.00");
     });
@@ -500,6 +551,7 @@ describe("ParseController", () => {
         $scope.ynab_map,
         $scope.inverted_outflow,
         $scope.inverted_amount,
+        $scope.fix_dates,
       );
     });
 
@@ -633,6 +685,7 @@ describe("ParseController", () => {
         $scope.ynab_map,
         $scope.inverted_outflow,
         $scope.inverted_amount,
+        $scope.fix_dates,
       );
 
       // Verify worksheet initialization
@@ -919,6 +972,7 @@ describe("ParseController", () => {
         $scope.ynab_map,
         $scope.inverted_outflow,
         $scope.inverted_amount,
+        $scope.fix_dates,
       );
 
       // Verify settings were saved
@@ -1302,6 +1356,7 @@ describe("ParseController", () => {
           extraRow: true,
           invertedOutflow: true,
           invertedAmount: true,
+          fixDates: true,
         };
 
         $scope.matchedConfig = { configId: "test-id" };
@@ -1319,6 +1374,7 @@ describe("ParseController", () => {
         expect($scope.file.extraRow).toBe(true);
         expect($scope.inverted_outflow).toBe(true);
         expect($scope.inverted_amount).toBe(true);
+        expect($scope.fix_dates).toBe(true);
         expect(global.ConfigMatcher.incrementUsageCount).toHaveBeenCalledWith(
           "test-id",
         );
@@ -1382,6 +1438,7 @@ describe("ParseController", () => {
             extraRow: false,
             invertedOutflow: false,
             invertedAmount: false,
+            fixDates: false,
           },
           "My Config",
         );
@@ -1946,6 +2003,123 @@ describe("ParseController", () => {
         expect($scope.matchedConfig).toBeNull();
         expect($scope.autoApplied).toBe(false);
       });
+    });
+  });
+
+  describe("Fix Dates Auto-Detection", () => {
+    test("should auto-enable fix_dates when short year dates detected on file load", () => {
+      // Set up watchers
+      const watchCallbacks = {};
+      $scope.$watch.mockImplementation((expr, callback, deep) => {
+        watchCallbacks[expr] = callback;
+      });
+
+      // Re-initialize to capture watch callbacks
+      jest.resetModules();
+      require("../src/app.js");
+      const controllerCalls = mockModule.controller.mock.calls;
+      const parseControllerCall = controllerCalls.find(
+        (call) => call[0] === "ParseController",
+      );
+      const controllerFn = parseControllerCall[1];
+      controllerFn($scope, $location);
+
+      // Set up data object with hasShortYearDates
+      $scope.data_object.hasShortYearDates = jest.fn(() => true);
+      $scope.ynab_map = { Date: "Date", Payee: "Description" };
+
+      // Simulate file data change
+      const csvData = {
+        data: "Date,Description\n01/15/24,Purchase",
+        filename: "test.csv",
+      };
+
+      watchCallbacks["data.source"](csvData, null);
+
+      expect($scope.data_object.hasShortYearDates).toHaveBeenCalledWith("Date");
+      expect($scope.fix_dates).toBe(true);
+    });
+
+    test("should auto-enable fix_dates when Date mapping changes to column with short years", () => {
+      // Set up watchers
+      const watchCallbacks = {};
+      $scope.$watch.mockImplementation((expr, callback, deep) => {
+        watchCallbacks[expr] = callback;
+      });
+
+      // Re-initialize to capture watch callbacks
+      jest.resetModules();
+      require("../src/app.js");
+      const controllerCalls = mockModule.controller.mock.calls;
+      const parseControllerCall = controllerCalls.find(
+        (call) => call[0] === "ParseController",
+      );
+      const controllerFn = parseControllerCall[1];
+      controllerFn($scope, $location);
+
+      // Set up data object with hasShortYearDates
+      $scope.data_object.hasShortYearDates = jest.fn(() => true);
+
+      // Simulate mapping change where Date column changes
+      const newMapping = { Date: "Trans Date", Payee: "Merchant" };
+      const oldMapping = { Date: "Other", Payee: "Merchant" };
+      watchCallbacks["ynab_map"](newMapping, oldMapping);
+
+      expect($scope.data_object.hasShortYearDates).toHaveBeenCalledWith(
+        "Trans Date",
+      );
+      expect($scope.fix_dates).toBe(true);
+    });
+
+    test("should include fixDates in saveCurrentConfig settings", () => {
+      global.ConfigMatcher.saveConfiguration.mockReturnValue("config-id");
+      global.ConfigMatcher.getConfiguration.mockReturnValue({
+        id: "config-id",
+        name: "Test",
+      });
+      global.ConfigMatcher.getAllConfigurations.mockReturnValue({});
+
+      $scope.data_object.base_json = {
+        data: [],
+        meta: { fields: ["Date", "Amount"] },
+      };
+      $scope.data_object.fields = jest.fn(() => ["Date", "Amount"]);
+      $scope.fix_dates = true;
+
+      $scope.saveCurrentConfig("Test");
+
+      expect(global.ConfigMatcher.saveConfiguration).toHaveBeenCalledWith(
+        ["Date", "Amount"],
+        null,
+        expect.objectContaining({
+          fixDates: true,
+        }),
+        "Test",
+      );
+    });
+
+    test("should include fixDates in updateMatchedConfig settings", () => {
+      $scope.matchedConfig = {
+        configId: "existing-id",
+        config: { name: "Old" },
+      };
+
+      global.ConfigMatcher.updateConfiguration.mockReturnValue(true);
+      global.ConfigMatcher.getConfiguration.mockReturnValue({
+        name: "Updated",
+      });
+      global.ConfigMatcher.getAllConfigurations.mockReturnValue({});
+
+      $scope.fix_dates = true;
+
+      $scope.updateMatchedConfig();
+
+      expect(global.ConfigMatcher.updateConfiguration).toHaveBeenCalledWith(
+        "existing-id",
+        expect.objectContaining({
+          fixDates: true,
+        }),
+      );
     });
   });
 });

--- a/tests/data_object.test.js
+++ b/tests/data_object.test.js
@@ -1048,4 +1048,144 @@ describe("DataObject", () => {
       });
     });
   });
+
+  describe("fixTwoDigitYear", () => {
+    test("should convert MM/DD/YY to MM/DD/20YY", () => {
+      expect(DataObject.fixTwoDigitYear("01/15/24")).toBe("01/15/2024");
+    });
+
+    test("should convert DD.MM.YY to DD.MM.20YY", () => {
+      expect(DataObject.fixTwoDigitYear("15.01.24")).toBe("15.01.2024");
+    });
+
+    test("should convert DD-MM-YY to DD-MM-20YY", () => {
+      expect(DataObject.fixTwoDigitYear("15-01-24")).toBe("15-01-2024");
+    });
+
+    test("should convert YY-MM-DD to 20YY-MM-DD when year > 31", () => {
+      expect(DataObject.fixTwoDigitYear("99-01-15")).toBe("2099-01-15");
+    });
+
+    test("should convert YY/MM/DD to 20YY/MM/DD when year > 31", () => {
+      expect(DataObject.fixTwoDigitYear("99/01/15")).toBe("2099/01/15");
+    });
+
+    test("should handle single-digit day/month", () => {
+      expect(DataObject.fixTwoDigitYear("1/5/24")).toBe("1/5/2024");
+    });
+
+    test("should not modify dates that already have 4-digit year", () => {
+      expect(DataObject.fixTwoDigitYear("01/15/2024")).toBe("01/15/2024");
+      expect(DataObject.fixTwoDigitYear("2024-01-15")).toBe("2024-01-15");
+    });
+
+    test("should return null/empty unchanged", () => {
+      expect(DataObject.fixTwoDigitYear(null)).toBe(null);
+      expect(DataObject.fixTwoDigitYear("")).toBe("");
+      expect(DataObject.fixTwoDigitYear(undefined)).toBe(undefined);
+    });
+  });
+
+  describe("hasShortYearDates", () => {
+    test("should return true when majority of dates have 2-digit years", () => {
+      dataObject.base_json = {
+        data: [
+          { Date: "01/15/24" },
+          { Date: "02/20/24" },
+          { Date: "03/10/24" },
+        ],
+      };
+
+      expect(dataObject.hasShortYearDates("Date")).toBe(true);
+    });
+
+    test("should return false when dates have 4-digit years", () => {
+      dataObject.base_json = {
+        data: [
+          { Date: "01/15/2024" },
+          { Date: "02/20/2024" },
+          { Date: "03/10/2024" },
+        ],
+      };
+
+      expect(dataObject.hasShortYearDates("Date")).toBe(false);
+    });
+
+    test("should return false when no data", () => {
+      dataObject.base_json = null;
+      expect(dataObject.hasShortYearDates("Date")).toBe(false);
+    });
+
+    test("should return false when column name is empty", () => {
+      dataObject.base_json = { data: [{ Date: "01/15/24" }] };
+      expect(dataObject.hasShortYearDates("")).toBe(false);
+      expect(dataObject.hasShortYearDates(null)).toBe(false);
+    });
+
+    test("should only sample first 10 rows", () => {
+      const rows = [];
+      for (let i = 0; i < 20; i++) {
+        rows.push({ Date: "01/15/24" });
+      }
+      dataObject.base_json = { data: rows };
+
+      expect(dataObject.hasShortYearDates("Date")).toBe(true);
+    });
+  });
+
+  describe("converted_json with fix_dates", () => {
+    beforeEach(() => {
+      dataObject.base_json = {
+        data: [
+          { Date: "01/15/24", Description: "Purchase", Amount: "-50.00" },
+          { Date: "02/20/24", Description: "Salary", Amount: "1000.00" },
+        ],
+        meta: { fields: ["Date", "Description", "Amount"] },
+      };
+    });
+
+    test("should fix dates when fix_dates is true", () => {
+      const ynab_cols = ["Date", "Payee", "Memo", "Amount"];
+      const lookup = {
+        Date: "Date",
+        Payee: "Description",
+        Memo: "Description",
+        Amount: "Amount",
+      };
+
+      const result = dataObject.converted_json(
+        null,
+        ynab_cols,
+        lookup,
+        false,
+        false,
+        true,
+      );
+
+      expect(result[0].Date).toBe("01/15/2024");
+      expect(result[1].Date).toBe("02/20/2024");
+    });
+
+    test("should not fix dates when fix_dates is false", () => {
+      const ynab_cols = ["Date", "Payee", "Memo", "Amount"];
+      const lookup = {
+        Date: "Date",
+        Payee: "Description",
+        Memo: "Description",
+        Amount: "Amount",
+      };
+
+      const result = dataObject.converted_json(
+        null,
+        ynab_cols,
+        lookup,
+        false,
+        false,
+        false,
+      );
+
+      expect(result[0].Date).toBe("01/15/24");
+      expect(result[1].Date).toBe("02/20/24");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a "Fix dates" toggle that converts 2-digit years to 4-digit years (e.g. `01/15/24` → `01/15/2024`) by prepending "20"
- Auto-detects 2-digit years in the Date column and enables the toggle automatically
- Persists the setting in saved configurations

## Test plan
- [x] All 246 tests pass (`npx jest`)
- [ ] Load a CSV with 2-digit year dates → "Fix dates" button auto-activates and preview shows 4-digit years
- [ ] Toggle button off → preview reverts to 2-digit years
- [ ] Download file → exported CSV has 4-digit years when toggle is on
- [ ] Save config → reload → fix_dates setting is preserved